### PR TITLE
Fix dependices 2.3.2

### DIFF
--- a/MediKit/build.gradle
+++ b/MediKit/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Si jamais le projet ne marche pas chez vous il faut juste mettre à jour votre android studio à la dernière maj !